### PR TITLE
Fix flaky test_search_attribute_get

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ from pkg_resources import resource_filename
 import json
 import pytest
 
+from atlasclient.client import Atlas
 from atlasclient import client
 from atlasclient import exceptions
 GUID = '8bbea92b-d98c-4613-ae6e-1a9d0b4f344b'
@@ -452,6 +453,7 @@ class TestRelationshipREST():
 
 class TestDiscoveryREST():
     def test_search_attribute_get(self, mocker, atlas_client, search_attribute_response):
+        client = Atlas('localhost', port=21000, username='admin', password='admin')
         mocker.patch.object(atlas_client.search_attribute.client, 'get')
         atlas_client.search_attribute.client.get.return_value =  search_attribute_response 
         params = {'attrName': 'attrName', 'attrValue': 'attrVal', 'offset': '1'}


### PR DESCRIPTION
# What is the purpose of the change
- This PR is to fix a flaky test `tests/test_models.py::TestDiscoveryREST::test_search_attribute_get`, which can fail after running `tests/test_models.py::TestDiscoveryREST::test_search_basic_get`, but passes when it is run in isolation.

# Reproduce the test failure
- Run the following command:
```
python -m pytest tests/test_models.py::TestDiscoveryREST::test_search_basic_get tests/test_models.py::TestDiscoveryREST::test_search_attribute_get
```

# Expected result
- Test `tests/test_models.py::TestDiscoveryREST::test_search_attribute_get` should pass when it is run after test `tests/test_models.py::TestDiscoveryREST::test_search_basic_get`.

# Actual result
- Test `tests/test_models.py::TestDiscoveryREST::test_search_attribute_get` fails:
```
E           AssertionError: assert 'BASIC' == 'GREMLIN'
E             - GREMLIN
E             + BASIC

tests/test_models.py:462: AssertionError

```
# Why it fails:
- `search_attribute_response` will be set to `BASIC` after ``tests/test_models.py::TestDiscoveryREST::test_search_basic_get``, which will pollute the state.

# Fix 
- Reset the client.